### PR TITLE
Fix TypeError by ensuring thread_number is an integer in download_fil…

### DIFF
--- a/DriveDownloader/downloader.py
+++ b/DriveDownloader/downloader.py
@@ -108,8 +108,10 @@ def download_filelist(args):
     lines = [line for line in open(args.url, 'r')]
     for line_idx, line in enumerate(lines):
         splitted_line = line.strip().split(" ")
+        url, filename = splitted_line[0], splitted_line[1] if len(splitted_line) > 1 else ""
+        thread_number = int(splitted_line[2]) if len(splitted_line) > 2 else 1
         list_suffix = "({:d}/{:d})".format(line_idx+1, len(lines))
-        download_single_file(*splitted_line, args.thread_number, list_suffix)
+        download_single_file(url, filename, thread_number, args.force_back_google, list_suffix)
 
 def simple_cli():
     console.print(f"***********************************************************************")


### PR DESCRIPTION
For a input list:
```
https://xxxx-my.sharepoint.com/:u:/g/personal/xx_xx_xxx/EfXu74QoeLFJtwqdUTBdcf8Bgj-vOgtnDJ0w7GQRpswJzg?e=xxx
...
```

This comparison is not valid in Python, leading to the `TypeError: '>' not supported between instances of 'str' and 'int' error`.

The error is caused by a type mismatch when comparing a string and an integer in the `download_single_file` function. The `thread_number` is expected to be an integer, but a string is passed in when the function is called in `download_filelist`. This happens because `splitted_line` is a list of strings, and when `*splitted_line` is used to call `download_single_file`, all elements are treated as strings.

To fix this, you need to ensure `thread_number` is an integer. You can convert it to an integer before calling `download_single_file`. 

In this fix, I first extract `url` and `filename` from `splitted_line`, then try to extract `thread_number` and convert it to an integer. If `thread_number` is not in `splitted_line`, it defaults to 1. Then, I pass these parameters to `download_single_file`.