### PR TITLE
Fix progress bar bug when download multiple files.

### DIFF
--- a/DriveDownloader/downloader.py
+++ b/DriveDownloader/downloader.py
@@ -24,30 +24,6 @@ MINOR_VERSION = 6
 POST_VERSION = 0
 __version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}.{POST_VERSION}"
 console = Console(width=72)
-single_progress = Progress(
-    TextColumn("[bold blue]Downloading: ", justify="left"),
-    BarColumn(bar_width=15),
-    "[progress.percentage]{task.percentage:>3.1f}%",
-    "|",
-    DownloadColumn(),
-    "|",
-    TransferSpeedColumn(),
-    "|",
-    TimeRemainingColumn(),
-    refresh_per_second=10
-)
-multi_progress = Progress(
-    TextColumn("[bold blue]Thread {task.fields[proc_id]}: ", justify="left"),
-    BarColumn(bar_width=15),
-    "[progress.percentage]{task.percentage:>3.1f}%",
-    "|",
-    DownloadColumn(),
-    "|",
-    TransferSpeedColumn(),
-    "|",
-    TimeRemainingColumn(),
-    refresh_per_second=10
-)
 url_scheme_env_key_map = {
         "http": "http_proxy",
         "https": "https_proxy",
@@ -82,6 +58,30 @@ def download_single_file(url, filename="", thread_number=1, force_back_google=Fa
     if session_name == 'GoogleDrive' and thread_number > 1 and not force_back_google:
         thread_number = 1
         google_fix_logic = True
+    single_progress = Progress(
+        TextColumn("[bold blue]Downloading: ", justify="left"),
+        BarColumn(bar_width=15),
+        "[progress.percentage]{task.percentage:>3.1f}%",
+        "|",
+        DownloadColumn(),
+        "|",
+        TransferSpeedColumn(),
+        "|",
+        TimeRemainingColumn(),
+        refresh_per_second=10
+    )
+    multi_progress = Progress(
+        TextColumn("[bold blue]Thread {task.fields[proc_id]}: ", justify="left"),
+        BarColumn(bar_width=15),
+        "[progress.percentage]{task.percentage:>3.1f}%",
+        "|",
+        DownloadColumn(),
+        "|",
+        TransferSpeedColumn(),
+        "|",
+        TimeRemainingColumn(),
+        refresh_per_second=10
+    )
     progress_applied = multi_progress if thread_number > 1 else single_progress
     download_session = session_func(used_proxy)
     download_session.connect(url, filename, force_backup=force_back_google if session_name == 'GoogleDrive' else False)


### PR DESCRIPTION
Change the global var *single_progress* and *multi_progress* to local var, fixing the progress bar display bug caused by reusing progress bar var.
<img width="677" alt="455396045-566392a5-7194-497e-87cd-c27523ed791a" src="https://github.com/user-attachments/assets/8051c210-5602-47ec-a128-2c30d189f5b8" />


Here is my environment, where the bug can be reproduced:
rich                       14.0.0
DriveDownloader            1.6.0.post1
python                 3.13.4
OS: Ubuntu 20.04.6 LTS x86_64 

tests/test.list:
https://stuxidianeducn-my.sharepoint.com/:u:/g/personal/pengwu_stu_xidian_edu_cn/ERiQQLUAex1CnwuBIEOK9YgBtcqU3hR_ZDtahCwLtVVkew?e=QHJ3bz data/Training_Videos_1.zip
https://stuxidianeducn-my.sharepoint.com/:u:/g/personal/pengwu_stu_xidian_edu_cn/EU-CqR-yYmVEqlFR1qHs3ZwB_Xfmi9d2augzSoOgDM66ug?e=gNNLIR data/Training_Videos_2.zip


On branch master
Changes to be committed:
        modified:   DriveDownloader/downloader.py